### PR TITLE
suspend PriorityQueue when no message is available(fix #14)

### DIFF
--- a/Sources/HPRTMP/RTMPSocket.swift
+++ b/Sources/HPRTMP/RTMPSocket.swift
@@ -165,7 +165,8 @@ extension RTMPSocket {
   private func startSendMessages() {
     let task = Task {
       while !Task.isCancelled {
-        let messageContainer = await messagePriorityQueue.dequeue()
+        guard let messageContainer = await messagePriorityQueue.dequeue() else { break }
+
         let message = messageContainer.message
         let isFirstType = messageContainer.isFirstType
         // windows sizeが超えた場合acknowledgementまち

--- a/Sources/HPRTMP/RTMPSocket.swift
+++ b/Sources/HPRTMP/RTMPSocket.swift
@@ -165,7 +165,7 @@ extension RTMPSocket {
   private func startSendMessages() {
     let task = Task {
       while !Task.isCancelled {
-        guard let messageContainer = await messagePriorityQueue.dequeue() else { continue }
+        let messageContainer = await messagePriorityQueue.dequeue()
         let message = messageContainer.message
         let isFirstType = messageContainer.isFirstType
         // windows sizeが超えた場合acknowledgementまち

--- a/Sources/HPRTMP/Util/PriorityQueue.swift
+++ b/Sources/HPRTMP/Util/PriorityQueue.swift
@@ -17,6 +17,7 @@ actor PriorityQueue {
   private var highPriorityQueue: [MessageContainer] = []
   private var mediumPriorityQueue: [MessageContainer] = []
   private var lowPriorityQueue: [MessageContainer] = []
+  private var waitMessageContinuation: CheckedContinuation<Void, Never>? = nil
   
   func enqueue(_ message: RTMPMessage, firstType: Bool) {
     let container = MessageContainer(message: message, isFirstType: firstType)
@@ -28,17 +29,24 @@ actor PriorityQueue {
     case .low:
       lowPriorityQueue.append(container)
     }
+    
+    waitMessageContinuation?.resume()
+    waitMessageContinuation = nil
   }
   
-  func dequeue() -> MessageContainer? {
-    if !highPriorityQueue.isEmpty {
-      return highPriorityQueue.removeFirst()
-    } else if !mediumPriorityQueue.isEmpty {
-      return mediumPriorityQueue.removeFirst()
-    } else if !lowPriorityQueue.isEmpty {
-      return lowPriorityQueue.removeFirst()
-    } else {
-      return nil
+  func dequeue() async -> MessageContainer {
+    while true {
+      if !highPriorityQueue.isEmpty {
+        return highPriorityQueue.removeFirst()
+      } else if !mediumPriorityQueue.isEmpty {
+        return mediumPriorityQueue.removeFirst()
+      } else if !lowPriorityQueue.isEmpty {
+        return lowPriorityQueue.removeFirst()
+      } else {
+        await withCheckedContinuation { cont in
+          self.waitMessageContinuation = cont
+        }
+      }
     }
   }
   

--- a/Sources/HPRTMP/Util/PriorityQueue.swift
+++ b/Sources/HPRTMP/Util/PriorityQueue.swift
@@ -34,8 +34,8 @@ actor PriorityQueue {
     waitMessageContinuation = nil
   }
   
-  func dequeue() async -> MessageContainer {
-    while true {
+  func dequeue() async -> MessageContainer? {
+    while !Task.isCancelled {
       if !highPriorityQueue.isEmpty {
         return highPriorityQueue.removeFirst()
       } else if !mediumPriorityQueue.isEmpty {
@@ -43,11 +43,15 @@ actor PriorityQueue {
       } else if !lowPriorityQueue.isEmpty {
         return lowPriorityQueue.removeFirst()
       } else {
-        await withCheckedContinuation { cont in
-          self.waitMessageContinuation = cont
+        await withTaskCancellationHandler {
+          await withCheckedContinuation { cont in
+            self.waitMessageContinuation = cont
+          }
+        } onCancel: {
         }
       }
     }
+    return nil
   }
   
   var isEmpty: Bool {


### PR DESCRIPTION
Now PriorityQueue::deque() becomes async and always return MessageContainer and never return nil. When no message is available, sleep with withCheckedContinuation until new message is comming.

With this change, HPRTMPExample CPU load becomes 14% for my iPhone 14 pro (previous: more than 100%).