### PR TITLE
Fix task leak in RTMPSocket

### DIFF
--- a/Sources/HPRTMP/Core/RTMPSocket.swift
+++ b/Sources/HPRTMP/Core/RTMPSocket.swift
@@ -142,9 +142,10 @@ extension RTMPSocket {
     do {
       try await connection.connect(host: urlInfo.host, port: urlInfo.port)
       status = .open
-      Task {
+      let task = Task {
         await self.startShakeHands()
       }
+      tasks.append(task)
     } catch {
       self.logger.error("[HPRTMP] connection error: \(error.localizedDescription)")
       await self.delegate?.socketError(self, err: .uknown(desc: error.localizedDescription))
@@ -175,6 +176,7 @@ extension RTMPSocket {
     tasks.forEach {
       $0.cancel()
     }
+    tasks.removeAll()
     await handshake?.reset()
     await decoder.reset()
     try? await connection.close()


### PR DESCRIPTION
## Summary
- Fixed task array not being cleared in `invalidate()` causing task accumulation across multiple connections
- Fixed `startShakeHands` task not being tracked in `resume()`, preventing proper cancellation

## Changes
- `RTMPSocket.swift:178` - Added `tasks.removeAll()` after cancelling tasks
- `RTMPSocket.swift:145-148` - Track startShakeHands task by appending to tasks array

## Impact
Prevents resource leak when repeatedly connecting/disconnecting RTMP socket

## Test Plan
- [ ] Verify multiple connect/disconnect cycles don't accumulate tasks
- [ ] Verify all tasks are properly cancelled on invalidate()
- [ ] Run existing unit tests