### PR TITLE
Fix connect API to actually establish connection

### DIFF
--- a/Sources/HPRTMP/Core/RTMPSocket.swift
+++ b/Sources/HPRTMP/Core/RTMPSocket.swift
@@ -128,9 +128,10 @@ public actor RTMPSocket {
     await resume()
   }
   
-  public func connect(streamURL: URL, streamKey: String, port: Int = 1935) {
+  public func connect(streamURL: URL, streamKey: String, port: Int = 1935) async {
     let urlInfo = RTMPURLInfo(url: streamURL, appName: "", key: streamKey, port: port)
     self.urlInfo = urlInfo
+    await resume()
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixed `connect(streamURL:streamKey:port:)` to actually establish RTMP connection
- Added `async` modifier to function signature
- Added `await resume()` call to trigger connection establishment
- Now consistent with `connect(url:)` behavior

## Changes
The `connect(streamURL:streamKey:port:)` method previously only set the `urlInfo` property without actually establishing a connection. This caused the API to be misleading as callers would assume a connection was established after calling this method.

This PR fixes the issue by:
1. Making the function `async` 
2. Calling `await resume()` to actually establish the connection

## Test Plan
- [ ] Verify existing tests pass
- [ ] Test that calling `connect(streamURL:streamKey:port:)` now establishes a connection
- [ ] Confirm behavior matches `connect(url:)` method