### PR TITLE
Fix decode loop logic and state management bugs

### DIFF
--- a/Sources/HPRTMP/Codec/Chunk/MessageDecoder.swift
+++ b/Sources/HPRTMP/Codec/Chunk/MessageDecoder.swift
@@ -32,10 +32,11 @@ actor MessageDecoder {
     guard !isDecoding else { return nil }
     logger.debug("decode message start")
     isDecoding = true
+    defer { isDecoding = false }
+
     let (message,size) = await decodeMessage(data: data)
     guard let message else { return nil }
     data.removeFirst(size)
-    isDecoding = false
     logger.debug("MessageDecoder remain data count: \(self.data.count)")
     return message
   }


### PR DESCRIPTION
## Summary

Fix critical bugs in message decoding loop that could cause data loss or infinite loops:

1. **RTMPSocket decode loop** - Changed from relying on `remainDataCount` changes to checking actual message availability
2. **MessageDecoder state management** - Fixed `isDecoding` flag not being reset when decode fails

## Changes

### RTMPSocket.swift (Sources/HPRTMP/Core/RTMPSocket.swift:294-299)

**Before:**
```swift
var dataRemainCount = 0
while await decoder.remainDataCount != dataRemainCount, await decoder.remainDataCount != 0 {
    dataRemainCount = await decoder.remainDataCount
    await decode(data: data)
}
```

**After:**
```swift
while true {
    guard let message = await decoder.decode() else {
        break
    }
    await handleDecodedMessage(message)
}
```

**Why this matters:**
- Old logic relied on data count changes, not message completeness
- Could exit early if buffer was cleared
- Could infinite loop if decode failed without changing count
- New logic correctly exits when no complete message is available

### MessageDecoder.swift (Sources/HPRTMP/Codec/Chunk/MessageDecoder.swift:35)

**Before:**
```swift
isDecoding = true
let (message,size) = await decodeMessage(data: data)
guard let message else { return nil }  // isDecoding stuck at true!
data.removeFirst(size)
isDecoding = false
```

**After:**
```swift
isDecoding = true
defer { isDecoding = false }  // Always reset

let (message,size) = await decodeMessage(data: data)
guard let message else { return nil }
data.removeFirst(size)
```

**Why this matters:**
- When data was incomplete, `isDecoding` stayed `true` forever
- Next decode() call would immediately return nil (line 32 guard)
- Decoder permanently locked, no messages could be processed

## Impact

- ✅ Prevents data loss from premature loop exits
- ✅ Prevents infinite loops from stuck decode state
- ✅ Prevents decoder lockup when encountering incomplete data
- ✅ Cleaner, more maintainable code

## Test plan

- [ ] Test with incomplete RTMP data packets
- [ ] Test multiple rapid connect/disconnect cycles
- [ ] Test with different RTMP servers (YouTube, SRS, custom)
- [ ] Verify no message loss under network stress