### PR TITLE
Fix WindowControl ACK logic for YouTube and SRS compatibility

### DIFF
--- a/Tests/HPRTMPTests/Core/WindowControlTests.swift
+++ b/Tests/HPRTMPTests/Core/WindowControlTests.swift
@@ -59,15 +59,117 @@ final class WindowControlTests: XCTestCase {
     let windowControl = WindowControl()
 
     await windowControl.setWindowSize(240000)
-    
+
     for _ in 0..<5 {
       await windowControl.addOutBytesCount(50000)
     }
     var shouldWaitAcknowledgement = await windowControl.shouldWaitAcknowledgement
     XCTAssertTrue(shouldWaitAcknowledgement)
-    
+
     await windowControl.updateReceivedAcknowledgement(250000)
     shouldWaitAcknowledgement = await windowControl.shouldWaitAcknowledgement
     XCTAssertFalse(shouldWaitAcknowledgement)
+  }
+
+  // MARK: - ACK Mode Tests
+
+  func testYouTubeIncrementalMode() async {
+    let windowControl = WindowControl()
+
+    // YouTube sends same value (131325) every time
+    await windowControl.updateReceivedAcknowledgement(131325)
+    var received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 131325)
+
+    await windowControl.updateReceivedAcknowledgement(131325)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 262650) // 131325 * 2
+
+    await windowControl.updateReceivedAcknowledgement(131325)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 393975) // 131325 * 3
+
+    await windowControl.updateReceivedAcknowledgement(131325)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 525300) // 131325 * 4
+  }
+
+  func testSRSCumulativeMode() async {
+    let windowControl = WindowControl()
+
+    // SRS/NDS sends cumulative byte count
+    await windowControl.updateReceivedAcknowledgement(100000)
+    var received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 100000)
+
+    await windowControl.updateReceivedAcknowledgement(250000)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 250000)
+
+    await windowControl.updateReceivedAcknowledgement(400000)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 400000)
+
+    await windowControl.updateReceivedAcknowledgement(600000)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 600000)
+  }
+
+  func testYouTubeIncrementValueChange() async {
+    let windowControl = WindowControl()
+
+    // YouTube mode detected
+    await windowControl.updateReceivedAcknowledgement(100000)
+    await windowControl.updateReceivedAcknowledgement(100000)
+    var received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 200000)
+
+    // Increment value changes (should still work)
+    await windowControl.updateReceivedAcknowledgement(150000)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 350000) // 200000 + 150000
+
+    await windowControl.updateReceivedAcknowledgement(150000)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 500000) // 350000 + 150000
+  }
+
+  func testCumulativeModeACKDecrease() async {
+    let windowControl = WindowControl()
+
+    // SRS mode detected
+    await windowControl.updateReceivedAcknowledgement(100000)
+    await windowControl.updateReceivedAcknowledgement(250000)
+    var received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 250000)
+
+    // ACK decreased, should be ignored
+    await windowControl.updateReceivedAcknowledgement(200000)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 250000) // Should remain unchanged
+
+    // Normal ACK continues
+    await windowControl.updateReceivedAcknowledgement(300000)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 300000)
+  }
+
+  func testModeDetectionWithInitialDecrease() async {
+    let windowControl = WindowControl()
+
+    // First ACK
+    await windowControl.updateReceivedAcknowledgement(100000)
+    var received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 100000)
+
+    // Second ACK decreased (should default to cumulative mode)
+    await windowControl.updateReceivedAcknowledgement(50000)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 50000)
+
+    // Third ACK should work in cumulative mode
+    await windowControl.updateReceivedAcknowledgement(150000)
+    received = await windowControl.receivedAcknowledgement
+    XCTAssertEqual(received, 150000)
   }
 }


### PR DESCRIPTION
## Summary
Fixed WindowControl ACK handling to properly support different RTMP server types (YouTube, SRS, NDS).

## Changes
- **Auto-detection**: First 2 ACKs determine server behavior (incremental vs cumulative mode)
- **YouTube support**: Handles fixed increment values (e.g., 131325 every time)
- **SRS/NDS support**: Handles standard cumulative byte count
- **Defensive checks**: Prevents ACK decrease from breaking flow control
- **Clean refactoring**: Clear state machine with `AckMode` enum
- **Comprehensive tests**: 5 new test cases covering both modes and edge cases

## Problem
Previous logic used simple heuristic that failed in certain ACK sequences, potentially causing send deadlock.

## Test Plan
- ✅ All 8 WindowControl tests passing
- ✅ YouTube incremental mode (consecutive same values)
- ✅ SRS cumulative mode (increasing values)
- ✅ ACK value change handling
- ✅ ACK decrease protection