### PR TITLE
Fix graceful stream closure

### DIFF
--- a/Sources/HPRTMP/Session/RTMPPublishSession.swift
+++ b/Sources/HPRTMP/Session/RTMPPublishSession.swift
@@ -105,11 +105,11 @@ public actor RTMPPublishSession {
     // send closeStream
     let closeStreamMessage = CloseStreamMessage(msgStreamId: connectId)
     await socket.send(message: closeStreamMessage, firstType: true)
-    
-    // send deleteStream
+
+    // send deleteStream and wait for it to be sent
     let deleteStreamMessage = DeleteStreamMessage(msgStreamId: connectId)
-    await socket.send(message: deleteStreamMessage, firstType: true)
-    
+    await socket.sendAndWait(message: deleteStreamMessage, firstType: true)
+
     await self.socket.invalidate()
     self.publishStatus = .disconnected
   }

--- a/Sources/HPRTMP/Utils/Extensions/PriorityQueue.swift
+++ b/Sources/HPRTMP/Utils/Extensions/PriorityQueue.swift
@@ -12,6 +12,7 @@ actor MessagePriorityQueue {
   struct MessageContainer {
     let message: RTMPMessage
     let isFirstType: Bool
+    var continuation: CheckedContinuation<Void, Never>?
   }
   
   private var highPriorityQueue: [MessageContainer] = []
@@ -19,8 +20,8 @@ actor MessagePriorityQueue {
   private var lowPriorityQueue: [MessageContainer] = []
   private var waitMessageContinuation: CheckedContinuation<Void, Never>? = nil
   
-  func enqueue(_ message: RTMPMessage, firstType: Bool) {
-    let container = MessageContainer(message: message, isFirstType: firstType)
+  func enqueue(_ message: RTMPMessage, firstType: Bool, continuation: CheckedContinuation<Void, Never>? = nil) {
+    let container = MessageContainer(message: message, isFirstType: firstType, continuation: continuation)
     switch message.priority {
     case .high:
       highPriorityQueue.append(container)
@@ -29,7 +30,7 @@ actor MessagePriorityQueue {
     case .low:
       lowPriorityQueue.append(container)
     }
-    
+
     resumeWaitContinuationIfNeeded()
   }
   

--- a/Tests/HPRTMPTests/Utils/MessagePriorityQueueTests.swift
+++ b/Tests/HPRTMPTests/Utils/MessagePriorityQueueTests.swift
@@ -234,6 +234,19 @@ final class MessagePriorityQueueTests: XCTestCase {
     XCTAssertTrue(isEmpty)
   }
 
+  // MARK: - Continuation Tests
+
+  func testEnqueueWithoutContinuation() async {
+    let queue = MessagePriorityQueue()
+    let message = createMessage(priority: .medium)
+
+    await queue.enqueue(message, firstType: false, continuation: nil)
+
+    let container = await queue.dequeue()
+    XCTAssertNotNil(container)
+    XCTAssertNil(container?.continuation, "Container should have nil continuation when enqueued without one")
+  }
+
   // MARK: - Helper Methods
 
   private func createMessage(priority: MessagePriority, timestamp: UInt32 = 0) -> RTMPMessage {


### PR DESCRIPTION
## Summary
Fix race condition where connection closes before DeleteStreamMessage is fully sent, causing connectionInvalidated errors.

## Changes
- Added continuation support to `MessagePriorityQueue` to track message send completion
- Implemented `sendAndWait()` method in `RTMPSocket` that waits for message to be fully sent
- Updated `RTMPPublishSession.invalidate()` to wait for `DeleteStreamMessage` before closing connection
- Added test coverage for continuation functionality

## Problem
When closing a stream, `CloseStreamMessage` and `DeleteStreamMessage` were queued but `invalidate()` immediately closed the connection, causing:
- Messages might not be fully sent
- `connectionInvalidated` errors in receive task
- Ungraceful disconnection

## Solution
- Normal `send()` remains async/non-blocking for performance
- New `sendAndWait()` waits for message completion using continuation
- Only used for critical close messages to ensure clean shutdown
- Zero performance impact on normal streaming (just one nil check per message)

## Test Results
All 149 tests passing ✅