### PR TITLE
Refactor RTMPPublishSession to use AsyncStream

### DIFF
--- a/Example/HPRTMPExample/Shared/RTMPService.swift
+++ b/Example/HPRTMPExample/Shared/RTMPService.swift
@@ -67,7 +67,7 @@ actor RTMPService: ObservableObject {
     isRunning = true
   }
 
-  private func handleStatusChange(_ status: RTMPPublishSession.Status) async {
+  private func handleStatusChange(_ status: RTMPPublishStatus) async {
     if status == .publishStart {
       await reader.start()
     }
@@ -79,7 +79,7 @@ actor RTMPService: ObservableObject {
     await reader.stop()
     lastVideoTimestamp = 0
     lastAudioTimestamp = 0
-    await self.session.invalidate()
+    await self.session.stop()
 
     // Cancel monitoring tasks
     streamMonitoringTasks.forEach { $0.cancel() }

--- a/Sources/HPRTMP/Core/RTMPError.swift
+++ b/Sources/HPRTMP/Core/RTMPError.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum RTMPError: Error, Sendable {
+public enum RTMPError: Error, Sendable, Equatable {
   case handShake(desc: String)
   case stream(desc: String)
   case command(desc: String)

--- a/Sources/HPRTMP/MessageHandler/Handlers/CommandMessageHandler.swift
+++ b/Sources/HPRTMP/MessageHandler/Handlers/CommandMessageHandler.swift
@@ -100,7 +100,7 @@ struct CommandMessageHandler: RTMPMessageHandler {
       context.updateStatus(.connected)
 
       let streamId = Int(commandMessage.info?.doubleValue ?? 0)
-      context.resumeCreateStream(commandMessage.transactionId, .success(streamId))
+      context.resumeCreateStream(commandMessage.transactionId, .success(MessageStreamId(streamId)))
     } else {
       logger.error("Create Stream failed, \(commandMessage.info.debugDescription)")
       let error = RTMPError.command(desc: "Create Stream error")

--- a/Sources/HPRTMP/MessageHandler/MessageHandlerContext.swift
+++ b/Sources/HPRTMP/MessageHandler/MessageHandlerContext.swift
@@ -38,7 +38,7 @@ struct MessageHandlerContext: Sendable {
   let resumeConnect: @Sendable (Result<Void, Error>) -> Void
 
   /// Resume the create stream continuation with transaction ID and result
-  let resumeCreateStream: @Sendable (Int, Result<Int, Error>) -> Void
+  let resumeCreateStream: @Sendable (Int, Result<MessageStreamId, Error>) -> Void
 
   /// Update the RTMPConnection status
   let updateStatus: @Sendable (RTMPStatus) -> Void

--- a/Sources/HPRTMP/Session/RTMPPublishSession.swift
+++ b/Sources/HPRTMP/Session/RTMPPublishSession.swift
@@ -82,12 +82,12 @@ public actor RTMPPublishSession: RTMPPublishSessionProtocol {
 
       // Send publish message
       let publishMsg = PublishMessage(encodeType: encodeType, streamName: await connection.urlInfo?.key ?? "", type: .live, msgStreamId: streamId)
-      await connection.send(message: publishMsg, firstType: true)
+      await connection.sendAndWait(message: publishMsg, firstType: true)
 
       // Send chunk size
       let chunkSize: UInt32 = 128 * 6
       let size = ChunkSizeMessage(size: chunkSize)
-      await connection.send(message: size, firstType: true)
+      await connection.sendAndWait(message: size, firstType: true)
     } catch let rtmpError as RTMPError {
       publishStatus = .failed(err: rtmpError)
     } catch {
@@ -163,7 +163,7 @@ public actor RTMPPublishSession: RTMPPublishSessionProtocol {
 
     // send closeStream
     let closeStreamMessage = CloseStreamMessage(msgStreamId: streamId)
-    await connection.send(message: closeStreamMessage, firstType: true)
+    await connection.sendAndWait(message: closeStreamMessage, firstType: true)
 
     // send deleteStream and wait for it to be sent
     let deleteStreamMessage = DeleteStreamMessage(msgStreamId: streamId)

--- a/Sources/HPRTMP/Session/RTMPPublishSessionProtocol.swift
+++ b/Sources/HPRTMP/Session/RTMPPublishSessionProtocol.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol defining the public interface for RTMP publishing sessions
+public protocol RTMPPublishSessionProtocol: Actor {
+  /// Current publishing status
+  var publishStatus: RTMPPublishStatus { get }
+
+  /// Stream of status updates
+  var statusStream: AsyncStream<RTMPPublishStatus> { get }
+
+  /// Stream of transmission statistics
+  var statisticsStream: AsyncStream<TransmissionStatistics> { get }
+
+  /// Start publishing to the specified RTMP URL
+  /// - Parameters:
+  ///   - url: The RTMP server URL
+  ///   - configure: Publishing configuration including metadata
+  func publish(url: String, configure: PublishConfigure) async
+
+  /// Publish video header data (sequence header)
+  /// - Parameter data: Video header data (e.g., SPS/PPS for H.264)
+  func publishVideoHeader(data: Data) async
+
+  /// Publish video frame data
+  /// - Parameters:
+  ///   - data: Video frame data
+  ///   - delta: Timestamp delta in milliseconds
+  func publishVideo(data: Data, delta: UInt32) async
+
+  /// Publish audio header data (sequence header)
+  /// - Parameter data: Audio header data (e.g., AAC config)
+  func publishAudioHeader(data: Data) async
+
+  /// Publish audio frame data
+  /// - Parameters:
+  ///   - data: Audio frame data
+  ///   - delta: Timestamp delta in milliseconds
+  func publishAudio(data: Data, delta: UInt32) async
+
+  /// Stop publishing and disconnect from the server
+  func stop() async
+}

--- a/Sources/HPRTMP/Session/RTMPPublishStatus.swift
+++ b/Sources/HPRTMP/Session/RTMPPublishStatus.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Represents the current status of an RTMP publishing session
+public enum RTMPPublishStatus: Equatable, Sendable {
+  /// Initial state before any connection attempt
+  case unknown
+
+  /// Handshake process has started
+  case handShakeStart
+
+  /// Handshake completed successfully
+  case handShakeDone
+
+  /// Connected to RTMP server
+  case connect
+
+  /// Publishing has started successfully
+  case publishStart
+
+  /// Session failed with an error
+  case failed(err: RTMPError)
+
+  /// Session disconnected
+  case disconnected
+}


### PR DESCRIPTION
## Summary
- Replace delegate pattern with AsyncStream for status and statistics updates
- Extract RTMPPublishSessionProtocol to define public interface
- Use MessageStreamId type consistently instead of raw Int
- Use sendAndWait for control messages to ensure delivery before state changes

## Changes
1. **AsyncStream Migration**: Replaced delegate callbacks with AsyncStream for status and statistics
2. **Protocol Extraction**: Created RTMPPublishSessionProtocol to hide implementation details
3. **Type Safety**: Refactored stream ID handling to use MessageStreamId type consistently
4. **Message Delivery**: Use sendAndWait for control messages (publish, chunkSize, closeStream, deleteStream)
5. **Error Handling**: Made RTMPError Equatable and improved error handling
6. **Resource Management**: Better cleanup of monitoring tasks and media header flags

## Test Plan
- [ ] Test publish and stop flow
- [ ] Verify status updates are received correctly
- [ ] Verify statistics updates are received correctly
- [ ] Test error cases and disconnection scenarios