### PR TITLE
Refactor timestamp handling: Message stores absolute timestamp, Encoder calculates delta

### DIFF
--- a/Sources/HPRTMP/Core/RTMPConnection.swift
+++ b/Sources/HPRTMP/Core/RTMPConnection.swift
@@ -246,6 +246,7 @@ extension RTMPConnection {
 
     await handshake?.reset()
     await decoder.reset()
+    await encoder.reset()
     try? await connection.close()
     urlInfo = nil
     status = .closed

--- a/Sources/HPRTMP/Core/RTMPMessageDefine.swift
+++ b/Sources/HPRTMP/Core/RTMPMessageDefine.swift
@@ -36,7 +36,7 @@ enum RTMPVideoCodecsType: UInt16 {
   case all       = 0x00FF
 }
 
-public enum MessageType: Equatable, Sendable {
+public enum MessageType: Equatable, Hashable, Sendable {
 
   // controll
   case chunkSize

--- a/Sources/HPRTMP/Session/RTMPPublishSessionProtocol.swift
+++ b/Sources/HPRTMP/Session/RTMPPublishSessionProtocol.swift
@@ -27,6 +27,12 @@ public protocol RTMPPublishSessionProtocol: Actor {
   ///   - delta: Timestamp delta in milliseconds
   func publishVideo(data: Data, delta: UInt32) async
 
+  /// Publish video frame data with absolute timestamp
+  /// - Parameters:
+  ///   - data: Video frame data
+  ///   - timestamp: Absolute timestamp in milliseconds
+  func publishVideo(data: Data, timestamp: UInt32) async
+
   /// Publish audio header data (sequence header)
   /// - Parameter data: Audio header data (e.g., AAC config)
   func publishAudioHeader(data: Data) async
@@ -36,6 +42,12 @@ public protocol RTMPPublishSessionProtocol: Actor {
   ///   - data: Audio frame data
   ///   - delta: Timestamp delta in milliseconds
   func publishAudio(data: Data, delta: UInt32) async
+
+  /// Publish audio frame data with absolute timestamp
+  /// - Parameters:
+  ///   - data: Audio frame data
+  ///   - timestamp: Absolute timestamp in milliseconds
+  func publishAudio(data: Data, timestamp: UInt32) async
 
   /// Stop publishing and disconnect from the server
   func stop() async

--- a/Tests/HPRTMPTests/Codec/Chunk/MessageEncoderTests.swift
+++ b/Tests/HPRTMPTests/Codec/Chunk/MessageEncoderTests.swift
@@ -145,7 +145,8 @@ final class MessageEncoderTests: XCTestCase {
     XCTAssertTrue(chunks2[0].chunkHeader.messageHeader is MessageHeaderType2)
 
     let header2 = chunks2[0].chunkHeader.messageHeader as! MessageHeaderType2
-    XCTAssertEqual(header2.timestampDelta.value, 1033)
+    // Delta should be calculated as: message2.timestamp - message1.timestamp = 1033 - 1000 = 33
+    XCTAssertEqual(header2.timestampDelta.value, 33)
   }
 
   func testType1WhenMessageLengthChanges() async throws {


### PR DESCRIPTION
## Summary

This PR refactors the timestamp handling in RTMP publish flow to correctly separate concerns:

- **Messages now store absolute timestamps** instead of deltas
- **MessageEncoder calculates delta** during chunk encoding based on message type
- **New timestamp-based publish methods** for direct absolute timestamp usage
- **Backward compatible** delta-based methods that accumulate internally

## Changes

### 1. MessageType Hashable Support
- Added `Hashable` conformance to `MessageType` enum
- Enables using MessageType as dictionary key

### 2. MessageEncoder Refactoring
- Replaced hardcoded `lastVideoTimestamp`/`lastAudioTimestamp` with generic `lastTimestamps: [MessageType: Timestamp]` dictionary
- Now supports all MessageType automatically
- Added `reset()` method to clear encoder state
- Encoder calculates proper delta in `createMessageHeader()` based on last timestamp of same message type

### 3. RTMPPublishSession API Enhancement
- Added `publishVideo(data:timestamp:)` - direct absolute timestamp
- Added `publishAudio(data:timestamp:)` - direct absolute timestamp
- Modified `publishVideo(data:delta:)` - accumulates delta to absolute timestamp internally
- Modified `publishAudio(data:delta:)` - accumulates delta to absolute timestamp internally
- Timestamp state properly reset in `publish()` and `stop()`

## Benefits

- ✅ **Correct semantics**: Message timestamp = absolute time, Chunk delta = time difference
- ✅ **Extensible**: Automatic support for all MessageType, not limited to video/audio
- ✅ **Flexible API**: Support both delta and absolute timestamp workflows
- ✅ **Backward compatible**: Existing delta-based API still works

## Review Points

- Verify MessageEncoder correctly calculates delta for Type1/Type2 chunk headers
- Check timestamp reset logic in publish() and stop()
- Confirm backward compatibility of delta-based methods