### PR TITLE
Add RTMPS (RTMP over TLS) support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "43d741b009087adb005fd9d3341deb13aafd3565fce23b3247a2f75a03ca181b",
   "pins" : [
     {
       "identity" : "swift-atomics",
@@ -26,7 +27,16 @@
         "revision" : "702cd7c56d5d44eeba73fdf83918339b26dc855c",
         "version" : "2.62.0"
       }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl",
+      "state" : {
+        "revision" : "0cc3528ff48129d64ab9cab0b1cd621634edfc6b",
+        "version" : "2.29.3"
+      }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -14,12 +14,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.0.0"),
     ],
     targets: [
         .target(
             name: "HPRTMP",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio")
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl")
             ],
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency")

--- a/Sources/HPRTMP/Core/RTMPConnection.swift
+++ b/Sources/HPRTMP/Core/RTMPConnection.swift
@@ -149,7 +149,7 @@ extension RTMPConnection {
     self.urlInfo = urlInfo
 
     do {
-      try await connection.connect(host: urlInfo.host, port: urlInfo.port)
+      try await connection.connect(host: urlInfo.host, port: urlInfo.port, enableTLS: urlInfo.isSecure)
       status = .open
     } catch {
       logger.error("[HPRTMP] connection error: \(error.localizedDescription)")
@@ -228,10 +228,12 @@ extension RTMPConnection {
     try await establishConnection()
   }
 
-  public func connect(streamURL: URL, streamKey: String, port: Int = 1935) async throws {
-    let urlInfo = RTMPURLInfo(url: streamURL, appName: "", key: streamKey, port: port)
+  public func connect(streamURL: URL, streamKey: String, port: Int = 1935, enableTLS: Bool = false) async throws {
+    let scheme = enableTLS ? "rtmps" : "rtmp"
+    let urlInfo = RTMPURLInfo(url: streamURL, scheme: scheme, isSecure: enableTLS, appName: "", key: streamKey, port: port)
     self.urlInfo = urlInfo
-    try await openTransport(url: streamURL.absoluteString)
+    try await connection.connect(host: streamURL.host ?? "", port: port, enableTLS: enableTLS)
+    status = .open
     try await performHandshake()
     try await establishConnection()
   }

--- a/Sources/HPRTMP/Network/NetworkConnectable.swift
+++ b/Sources/HPRTMP/Network/NetworkConnectable.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol NetworkConnectable: Sendable {
-  func connect(host: String, port: Int) async throws
+  func connect(host: String, port: Int, enableTLS: Bool) async throws
   func sendData(_ data: Data) async throws
   func receiveData() async throws -> Data
   func close() async throws

--- a/Sources/HPRTMP/Utils/RTMPURLParser.swift
+++ b/Sources/HPRTMP/Utils/RTMPURLParser.swift
@@ -1,13 +1,15 @@
 import Foundation
 struct RTMPURLInfo {
   let url: URL
+  let scheme: String
+  let isSecure: Bool
   var tcUrl: String {
-    "rtmp://\(host)/\(appName)"
+    "\(scheme)://\(host)/\(appName)"
   }
   let appName: String
   let key: String
   let port: Int
-  
+
   var host: String {
     return url.host!
   }
@@ -26,20 +28,22 @@ struct RTMPURLParser {
     guard let parsedURL = URL(string: url) else {
       throw RTMPURLParsingError.invalidURL
     }
-    
-    guard let scheme = parsedURL.scheme, scheme == "rtmp" else {
+
+    guard let scheme = parsedURL.scheme, (scheme == "rtmp" || scheme == "rtmps") else {
       throw RTMPURLParsingError.invalidScheme
     }
-    
+
     let pathComponents = parsedURL.pathComponents
     guard pathComponents.count >= 3 else {
       throw RTMPURLParsingError.missingAppNameOrKey
     }
-    
+
     let appName = pathComponents[1]
     let key = pathComponents[2]
-    let port = parsedURL.port ?? 1935
-        
-    return RTMPURLInfo(url: parsedURL, appName: appName, key: key, port: port)
+    let isSecure = scheme == "rtmps"
+    let defaultPort = isSecure ? 443 : 1935
+    let port = parsedURL.port ?? defaultPort
+
+    return RTMPURLInfo(url: parsedURL, scheme: scheme, isSecure: isSecure, appName: appName, key: key, port: port)
   }
 }

--- a/Tests/HPRTMPTests/Core/RTMPHandshakeTests.swift
+++ b/Tests/HPRTMPTests/Core/RTMPHandshakeTests.swift
@@ -18,7 +18,7 @@ actor MockNetworkClient: NetworkConnectable {
     self.currentIndex = 0
   }
 
-  func connect(host: String, port: Int) async throws {
+  func connect(host: String, port: Int, enableTLS: Bool) async throws {
     // Mock implementation
   }
 

--- a/Tests/HPRTMPTests/Utils/RTMPURLParserTests.swift
+++ b/Tests/HPRTMPTests/Utils/RTMPURLParserTests.swift
@@ -14,10 +14,12 @@ final class RTMPURLParserTests: XCTestCase {
   func testParseValidURLWithDefaultPort() throws {
     let parser = RTMPURLParser()
     let url = "rtmp://example.com/live/stream"
-    let expectedURLInfo = RTMPURLInfo(url: URL(string: url)!, appName: "live", key: "stream", port: 1935)
-    
+    let expectedURLInfo = RTMPURLInfo(url: URL(string: url)!, scheme: "rtmp", isSecure: false, appName: "live", key: "stream", port: 1935)
+
     let result = try parser.parse(url: url)
     XCTAssertEqual(result?.url, expectedURLInfo.url)
+    XCTAssertEqual(result?.scheme, expectedURLInfo.scheme)
+    XCTAssertEqual(result?.isSecure, expectedURLInfo.isSecure)
     XCTAssertEqual(result?.appName, expectedURLInfo.appName)
     XCTAssertEqual(result?.key, expectedURLInfo.key)
     XCTAssertEqual(result?.port, expectedURLInfo.port)
@@ -28,10 +30,12 @@ final class RTMPURLParserTests: XCTestCase {
   func testParseValidURLWithCustomPart() throws {
     let parser = RTMPURLParser()
     let url = "rtmp://example.com:1937/live/stream"
-    let expectedURLInfo = RTMPURLInfo(url: URL(string: url)!, appName: "live", key: "stream", port: 1937)
-    
+    let expectedURLInfo = RTMPURLInfo(url: URL(string: url)!, scheme: "rtmp", isSecure: false, appName: "live", key: "stream", port: 1937)
+
     let result = try parser.parse(url: url)
     XCTAssertEqual(result?.url, expectedURLInfo.url)
+    XCTAssertEqual(result?.scheme, expectedURLInfo.scheme)
+    XCTAssertEqual(result?.isSecure, expectedURLInfo.isSecure)
     XCTAssertEqual(result?.appName, expectedURLInfo.appName)
     XCTAssertEqual(result?.key, expectedURLInfo.key)
     XCTAssertEqual(result?.port, expectedURLInfo.port)
@@ -42,9 +46,41 @@ final class RTMPURLParserTests: XCTestCase {
   func testParseInvalidURL() {
     let parser = RTMPURLParser()
     let url = "http://example.com/live/stream"
-    
+
     XCTAssertThrowsError(try parser.parse(url: url)) { error in
       XCTAssertEqual(error as? RTMPURLParsingError, RTMPURLParsingError.invalidScheme)
     }
+  }
+
+  func testParseValidRTMPSURLWithDefaultPort() throws {
+    let parser = RTMPURLParser()
+    let url = "rtmps://example.com/live/stream"
+    let expectedURLInfo = RTMPURLInfo(url: URL(string: url)!, scheme: "rtmps", isSecure: true, appName: "live", key: "stream", port: 443)
+
+    let result = try parser.parse(url: url)
+    XCTAssertEqual(result?.url, expectedURLInfo.url)
+    XCTAssertEqual(result?.scheme, expectedURLInfo.scheme)
+    XCTAssertEqual(result?.isSecure, expectedURLInfo.isSecure)
+    XCTAssertEqual(result?.appName, expectedURLInfo.appName)
+    XCTAssertEqual(result?.key, expectedURLInfo.key)
+    XCTAssertEqual(result?.port, expectedURLInfo.port)
+    XCTAssertEqual(result?.host, "example.com")
+    XCTAssertEqual(result?.tcUrl, "rtmps://example.com/live")
+  }
+
+  func testParseValidRTMPSURLWithCustomPort() throws {
+    let parser = RTMPURLParser()
+    let url = "rtmps://example.com:8443/live/stream"
+    let expectedURLInfo = RTMPURLInfo(url: URL(string: url)!, scheme: "rtmps", isSecure: true, appName: "live", key: "stream", port: 8443)
+
+    let result = try parser.parse(url: url)
+    XCTAssertEqual(result?.url, expectedURLInfo.url)
+    XCTAssertEqual(result?.scheme, expectedURLInfo.scheme)
+    XCTAssertEqual(result?.isSecure, expectedURLInfo.isSecure)
+    XCTAssertEqual(result?.appName, expectedURLInfo.appName)
+    XCTAssertEqual(result?.key, expectedURLInfo.key)
+    XCTAssertEqual(result?.port, expectedURLInfo.port)
+    XCTAssertEqual(result?.host, "example.com")
+    XCTAssertEqual(result?.tcUrl, "rtmps://example.com/live")
   }
 }


### PR DESCRIPTION
## Summary
Add support for secure RTMP streaming (RTMPS) with TLS/SSL encryption.

## Changes
- Add NIOSSL dependency for TLS support
- Support `rtmps://` URL scheme with default port 443
- Add TLS handler to network client pipeline
- Automatically enable TLS based on URL scheme
- Add comprehensive test cases for RTMPS

## Usage
```swift
// Use rtmps:// URL
try await connection.connect(url: "rtmps://example.com/live/stream")

// Or explicitly enable TLS
try await connection.connect(
    streamURL: url,
    streamKey: "key",
    port: 443,
    enableTLS: true
)
```

## Testing
- All existing tests pass
- Added RTMPS URL parsing tests
- Updated mock client for TLS support

## Notes
- RTMPS uses port 443 by default (configurable)
- Backward compatible with existing RTMP connections
- Ready for Facebook Live and future platform support